### PR TITLE
use single variable for returned value

### DIFF
--- a/fmoe/gates/utils.py
+++ b/fmoe/gates/utils.py
@@ -16,7 +16,7 @@ def limit_by_capacity(topk_idx, num_expert, world_size, capacity):
         new_gec = fmoe_native.limit_by_capacity(gec, capacity,
                 num_expert, world_size)
         if world_size > 1:
-            new_lec, = fmoe_native.expert_exchange(new_gec, num_expert,
+            new_lec = fmoe_native.expert_exchange(new_gec, num_expert,
                     world_size)
         else:
             new_lec = new_gec


### PR DESCRIPTION
the old impl raised error "too many values to unpack (expected 1)"