### PR TITLE
Added default weight initializations to FMoELinear and NoisyGate

### DIFF
--- a/fmoe/gates/noisy_gate.py
+++ b/fmoe/gates/noisy_gate.py
@@ -25,9 +25,9 @@ class NoisyGate(BaseGate):
 
         self.noise_epsilon = 1e-2
 
-        self._init_weights()
+        self.reset_parameters()
 
-    def _init_weights(self):
+    def reset_parameters(self):
         # Approach is the same as in torch.nn.Linear
         # https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/linear.py#L88
 

--- a/fmoe/gates/noisy_gate.py
+++ b/fmoe/gates/noisy_gate.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions.normal import Normal
+import math
 
 
 class NoisyGate(BaseGate):
@@ -23,6 +24,16 @@ class NoisyGate(BaseGate):
         self.softmax = nn.Softmax(1)
 
         self.noise_epsilon = 1e-2
+
+        self._init_weights()
+
+    def _init_weights(self):
+        # Approach is the same as in torch.nn.Linear
+        # https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/linear.py#L88
+
+        torch.nn.init.kaiming_uniform_(self.w_gate, a=math.sqrt(5))
+        torch.nn.init.kaiming_uniform_(self.w_noise, a=math.sqrt(5))
+
 
     def _gates_to_load(self, gates):
         """Compute the true load per expert, given the gates.

--- a/fmoe/layers.py
+++ b/fmoe/layers.py
@@ -38,7 +38,7 @@ class FMoELinear(nn.Module):
         else:
             self.register_parameter("bias", None)
 
-        self._init_weights()
+        self.reset_parameters()
 
     def forward(self, inp, fwd_expert_count):
         r"""
@@ -57,7 +57,7 @@ class FMoELinear(nn.Module):
             self.rank,
         )
 
-    def _init_weights(self):
+    def reset_parameters(self):
         # Approach is the same as in torch.nn.Linear
         # https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/linear.py#L88
         # bias is left to zero, similar as megatron

--- a/fmoe/layers.py
+++ b/fmoe/layers.py
@@ -3,6 +3,7 @@ Layers that FMoE provides to users
 """
 import torch
 import torch.nn as nn
+import math
 
 from .functions import prepare_forward
 from .functions import MOEScatter, MOEGather, MOELinear
@@ -33,9 +34,11 @@ class FMoELinear(nn.Module):
         self.rank = rank
         self.weight = nn.Parameter(torch.Tensor(num_expert, out_feat, in_feat))
         if bias:
-            self.bias = nn.Parameter(torch.Tensor(num_expert, out_feat))
+            self.bias = nn.Parameter(torch.zeros(num_expert, out_feat))
         else:
             self.register_parameter("bias", None)
+
+        self._init_weights()
 
     def forward(self, inp, fwd_expert_count):
         r"""
@@ -53,6 +56,13 @@ class FMoELinear(nn.Module):
             self.bias is not None,
             self.rank,
         )
+
+    def _init_weights(self):
+        # Approach is the same as in torch.nn.Linear
+        # https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/linear.py#L88
+        # bias is left to zero, similar as megatron
+
+        torch.nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
 
 
 def mark_module_parallel_comm(module, comm):


### PR DESCRIPTION
Some of the weight initializations were missing. torch.Tensor will simply store a random tensor with no guarantee of the range of values. The used distribution is the same used in `nn.Linear` which is the equivalent of a uniform