### PR TITLE
Fix typo in transformer example

### DIFF
--- a/examples/transformer-xl/mem_transformer.py
+++ b/examples/transformer-xl/mem_transformer.py
@@ -513,7 +513,7 @@ class AdaptiveEmbedding(nn.Module):
                 l_idx, r_idx = self.cutoff_ends[i], self.cutoff_ends[i+1]
                 d_emb_i = d_embed // (div_val ** i)
                 self.emb_layers.append(nn.Embedding(r_idx-l_idx, d_emb_i))
-                self.emb_projs.append(Projectio(d_proj, d_emb_i))
+                self.emb_projs.append(Projection(d_proj, d_emb_i))
 
     def forward(self, inp):
         if self.div_val == 1:


### PR DESCRIPTION
There is a typo ("Projectio") at line 516 of mem_transformer.py in the transformer_xl example.