### PR TITLE
FasterMoE Expert Shadowing

### DIFF
--- a/cuda/fastermoe/smart_schedule.cpp
+++ b/cuda/fastermoe/smart_schedule.cpp
@@ -19,6 +19,51 @@ void setSmartSchEnabled(int s) {
     smart_sch_enabled = s;
 }
 
+
+inline ncclDataType_t getNcclDataType(at::ScalarType t) {
+    switch (t) {
+        case at::kChar: return ncclInt8;
+        case at::kByte: return ncclUint8;
+        case at::kFloat: return ncclFloat;
+        case at::kDouble: return ncclDouble;
+        case at::kInt: return ncclInt32;
+        case at::kLong: return ncclInt64;
+        case at::kHalf: return ncclHalf;
+        case at::kBool: return ncclUint8;
+#if defined(ENABLE_NCCL_BF16_DATATYPE)
+        case at::kBFloat16: return ncclBfloat16;
+#endif
+        default: return ncclChar;
+    }
+}
+
+
+void _reduce_grad(
+        torch::Tensor t,
+        long root,
+        long expert_size) {
+    auto smgr = getCudaStreamManager(t.device().index());
+
+    auto torch_stream = c10::cuda::getCurrentCUDAStream().stream();
+    cudaEvent_t evt_stash;
+    cudaEventCreate(&evt_stash);
+    cudaEventRecord(evt_stash, torch_stream);
+    cudaStreamWaitEvent(smgr->stream(0), evt_stash, 0);
+    cudaEventDestroy(evt_stash);
+
+    auto dtype = getNcclDataType(t.scalar_type());
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(t.scalar_type(),
+        "fmoe_cuda_reduce_grad", ([&] {
+            void* buf = (void*)t.data_ptr<scalar_t>();
+            NCCL_SAFE_CALL(ncclReduce(buf, buf, expert_size,
+                        dtype,
+                        ncclSum, root,
+                        smgr->ncclcomm, smgr->stream(0)));
+        })
+    );
+}
+
+
 std::vector<torch::Tensor> _smart_sch_forward(
         torch::Tensor input_buf,
         torch::Tensor local_expert_count,
@@ -51,7 +96,6 @@ std::vector<torch::Tensor> _smart_sch_forward(
     // TODO: maybe empty is faster
     auto global_input_buf = input_buf.new_zeros({global_batch_size, d_model});
     auto global_output_buf = input_buf.new_zeros({global_batch_size, d_model});
-    
     auto output_buf = input_buf.new_zeros({input_buf.size(0), d_model});
 
     std::vector<torch::Tensor> params;
@@ -66,7 +110,7 @@ std::vector<torch::Tensor> _smart_sch_forward(
         }
     }
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_buf.scalar_type(), 
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_buf.scalar_type(),
             "fmoe_cuda_smart_sch_forward", ([&] {
         fmoe_cuda_fused_forward_impl(
             forward_fn,
@@ -96,7 +140,6 @@ torch::Tensor _smart_sch_backward(
         torch::Tensor stored_models,
         long buf_batch_size,
         long global_batch_size,
-        long expert_size,
         long n_workers,
         py::function backward_fn,
         py::function stash_fn,
@@ -112,10 +155,14 @@ torch::Tensor _smart_sch_backward(
     auto global_grad_in = grad_out.new_zeros({global_batch_size, d_model});
     auto grad_in = grad_out.new_zeros({buf_batch_size, d_model});
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_out.scalar_type(), 
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_out.scalar_type(),
             "fmoe_cuda_smartsch_backward", ([&] {
         fmoe_cuda_fused_backward_impl(
             backward_fn,
+            stash_fn,
+            pop_fn,
+            collect_fn,
+            set_grad_fn,
             grad_out.device(),
 
             grad_out.data_ptr<scalar_t>(),
@@ -129,7 +176,7 @@ torch::Tensor _smart_sch_backward(
             d_model, num_expert, rank, n_workers,
             pipeline_gran, smgr);
     }));
-    return {grad_in,};
+    return grad_in;
 }
 #endif
 

--- a/cuda/fastermoe/smart_schedule.h
+++ b/cuda/fastermoe/smart_schedule.h
@@ -168,7 +168,7 @@ void fmoe_cuda_fused_forward_impl(
                 cudaEventRecord(evt_get, torch_stream);
                 cudaStreamWaitEvent(smgr->stream(1), evt_get);
             }
-            NCCL_SAFE_CALL(ncclBcast(params[si].data_ptr<void>(), 
+            NCCL_SAFE_CALL(ncclBcast((void*)params[si].data_ptr<scalar_t>(), 
                         expert_size * sizeof(scalar_t), ncclChar,
                         i / num_expert, smgr->ncclcomm, smgr->stream(0)));
             cudaEventCreate(evt_shadow + si);

--- a/cuda/fmoe_cuda.cpp
+++ b/cuda/fmoe_cuda.cpp
@@ -77,13 +77,16 @@ torch::Tensor _smart_sch_backward(
         torch::Tensor stored_models,
         long buf_batch_size,
         long global_batch_size,
-        long expert_size,
         long n_workers,
         py::function backward_fn,
         py::function stash_fn,
         py::function pop_fn,
         py::function collect_fn,
         py::function set_grad_fn);
+void _reduce_grad(
+        torch::Tensor t,
+        long root,
+        long expert_size);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 #ifdef FMOE_USE_NCCL
@@ -95,6 +98,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
     m.def("smart_sch_forward", &_smart_sch_forward, "E2E MoE layer forward with smart scheduling");
     m.def("smart_sch_backward", &_smart_sch_backward, "E2E MoE layer backward with smart scheduling");
+    m.def("reduce_grad", &_reduce_grad, "Reduce gradients over FastMoE's communication stream");
 #endif
 
     m.def("expert_count", &_expert_count, "FastMoE count gate indices (CUDA)");

--- a/cuda/fmoe_cuda.cpp
+++ b/cuda/fmoe_cuda.cpp
@@ -80,6 +80,8 @@ torch::Tensor _smart_sch_backward(
         long expert_size,
         long n_workers,
         py::function backward_fn,
+        py::function stash_fn,
+        py::function pop_fn,
         py::function collect_fn,
         py::function set_grad_fn);
 

--- a/cuda/fmoe_cuda.cpp
+++ b/cuda/fmoe_cuda.cpp
@@ -63,8 +63,13 @@ std::vector<torch::Tensor> _smart_sch_forward(
         torch::Tensor local_expert_count,
         torch::Tensor global_expert_count,
         torch::Tensor stored_models,
-        long global_batch_size, long n_workers,
-        py::function forward_fn);
+        long global_batch_size,
+        long expert_size,
+        long n_workers,
+        py::function forward_fn,
+        py::function get_param_fn,
+        py::function stash_fn,
+        py::function pop_fn);
 torch::Tensor _smart_sch_backward(
         torch::Tensor grad_out,
         torch::Tensor local_expert_count,
@@ -72,8 +77,11 @@ torch::Tensor _smart_sch_backward(
         torch::Tensor stored_models,
         long buf_batch_size,
         long global_batch_size,
+        long expert_size,
         long n_workers,
-        py::function backward_fn);
+        py::function backward_fn,
+        py::function collect_fn,
+        py::function set_grad_fn);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 #ifdef FMOE_USE_NCCL

--- a/cuda/stream_manager.h
+++ b/cuda/stream_manager.h
@@ -21,13 +21,14 @@ public:
     int device;
     cublasHandle_t* handles;
     cudaStream_t* streams;
+    bool use_default;
 #ifdef FMOE_USE_NCCL
     char ncclgood;
     ncclComm_t ncclcomm;
 #endif
 
 public:
-    CudaStreamManager(int device_): device(device_) {
+    CudaStreamManager(int device_): device(device_), use_default(false) {
         this->setup(device);
     }
 

--- a/fmoe/fastermoe/config.py
+++ b/fmoe/fastermoe/config.py
@@ -1,0 +1,13 @@
+import os
+
+
+def float_from_env(key, default=-1):
+    if key in os.environ:
+        return float(os.environ[key])
+    return default
+
+
+def switch_from_env(key, default=False):
+    if key in os.environ:
+        return os.environ[key] in ['1', 'ON']
+    return default

--- a/fmoe/fastermoe/expert_utils.py
+++ b/fmoe/fastermoe/expert_utils.py
@@ -6,7 +6,6 @@ def get_expert_param_size(e):
     
 
 def get_expert_params(e, out):
-    print('gep to {}'.format(out))
     offset = 0
     for n, p in e.named_parameters():
         seg = out[offset:offset + p.numel()]
@@ -42,7 +41,7 @@ def collect_expert_grads(e, grads):
         seg = grads[offset:offset + p.numel()]
         offset += p.numel()
         if p.grad is not None:
-            seg.copy_(p.grad)
+            seg.copy_(p.grad.flatten())
             p.grad = None
         else:
             seg.zero_()
@@ -56,4 +55,4 @@ def set_grads(e, grads):
         if p.grad is None:
             p.grad = seg.clone()
         else:
-            p.grad += seg
+            p.grad += seg.reshape(p.shape)

--- a/fmoe/fastermoe/expert_utils.py
+++ b/fmoe/fastermoe/expert_utils.py
@@ -6,11 +6,12 @@ def get_expert_param_size(e):
     
 
 def get_expert_params(e, out):
+    print('gep to {}'.format(out))
     offset = 0
     for n, p in e.named_parameters():
         seg = out[offset:offset + p.numel()]
         offset += p.numel()
-        seg.copy_(p)
+        seg.copy_(p.data.flatten())
 
 
 def stash_expert_params(e, params):
@@ -27,6 +28,8 @@ def stash_expert_params(e, params):
 
 
 def pop_expert_params(e):
+    if not hasattr(e, 'expert_param_stash'):
+        return
     for n, p in e.named_parameters():
         with torch.no_grad():
             p.copy_(e.expert_param_stash[n])

--- a/fmoe/fastermoe/expert_utils.py
+++ b/fmoe/fastermoe/expert_utils.py
@@ -1,0 +1,56 @@
+import torch
+
+
+def get_expert_param_size(e):
+    return sum(map(lambda x: x.numel(), e.parameters()))
+    
+
+def get_expert_params(e, out):
+    offset = 0
+    for n, p in e.named_parameters():
+        seg = out[offset:offset + p.numel()]
+        offset += p.numel()
+        seg.copy_(p)
+
+
+def stash_expert_params(e, params):
+    if not hasattr(e, 'expert_param_stash'):
+        setattr(e, 'expert_param_stash', dict())
+    offset = 0
+    for n, p in e.named_parameters():
+        if n not in e.expert_param_stash:
+            e.expert_param_stash[n] = p.data.clone()
+        with torch.no_grad():
+            seg = params[offset:offset + p.numel()]
+            offset += p.numel()
+            p.copy_(seg.reshape(p.shape))
+
+
+def pop_expert_params(e):
+    for n, p in e.named_parameters():
+        with torch.no_grad():
+            p.copy_(e.expert_param_stash[n])
+    e.expert_param_stash.clear()
+
+
+def collect_expert_grads(e, grads):
+    offset = 0
+    for _, p in e.named_parameters():
+        seg = grads[offset:offset + p.numel()]
+        offset += p.numel()
+        if p.grad is not None:
+            seg.copy_(p.grad)
+            p.grad = None
+        else:
+            seg.zero_()
+
+
+def set_grads(e, grads):
+    offset = 0
+    for n, p in e.named_parameters():
+        seg = grads[offset:offset + p.numel()]
+        offset += p.numel()
+        if p.grad is None:
+            p.grad = seg.clone()
+        else:
+            p.grad += seg

--- a/fmoe/fastermoe/schedule.py
+++ b/fmoe/fastermoe/schedule.py
@@ -7,6 +7,7 @@ from torch.autograd.function import Function
 from fmoe.functions import prepare_forward, ensure_comm
 from fmoe.functions import _local_scatter, _local_gather 
 import fmoe_cuda as fmoe_native
+import expert_utils
 
 
 class MoEForward(Function):
@@ -14,6 +15,7 @@ class MoEForward(Function):
     def forward(
             ctx,
             expert_fn,
+            experts,
             inp, # models,
             pos_s, pos_g,
             local_expert_count, global_expert_count,
@@ -25,8 +27,8 @@ class MoEForward(Function):
         # TODO: leave this for furture work of expert shadowing
         # model_params = [[tuple(m.parameters()) for m in node] for node in models]
 
-        ctx.gibs = [None] * world_size
-        ctx.gobs = [None] * world_size
+        ctx.gibs = [None] * (world_size * 2)
+        ctx.gobs = [None] * (world_size * 2)
         def _expert_forward(x, y, idx):
             x = x.data
             with torch.enable_grad():
@@ -36,11 +38,23 @@ class MoEForward(Function):
             ctx.gobs[idx] = y0
             y.copy_(y0)
 
+        ctx.experts = experts
+        if stored_models.any():
+            ctx.expert_size = expert_utils.get_expert_param_size(experts)
+        else:
+            ctx.expert_size = 0
+        get_param_fn = lambda out: expert_utils.get_expert_params(experts, out)
+        pop_fn = lambda: expert_utils.pop_expert_params(experts)
+        ctx.shadows = [None] * world_size
+        def stash_fn(params, idx):
+            expert_utils.stash_expert_params(experts, p)
+            ctx.shadows[idx] = params
+
         local_output_buf, gib = fmoe_native.smart_sch_forward(
                 local_input_buf,
                 local_expert_count, global_expert_count, 
-                stored_models, fwd_batch_size,
-                world_size, _expert_forward)
+                stored_models, fwd_batch_size, ctx.expert_size,
+                world_size, _expert_forward, get_param_fn, stash_fn, pop_fn)
 
         out = _local_gather(local_output_buf, pos_g, out_batch_size,
                 maybe_overlap=False)
@@ -65,19 +79,27 @@ class MoEForward(Function):
             x = ctx.gibs[idx]
             grad_x.copy_(x.grad)
 
+        experts = ctx.experts
+        def stash_fn(idx):
+            expert_utils.stash_expert_params(experts, ctx.shadows[idx])
+        pop_fn = lambda: expert_utils.pop_expert_params(experts)
+        collect_fn = lambda g: expert_utils.collect_expert_grads(experts, g)
+        set_grad_fn = lambda g: expert_utils.set_grads(experts, g)
+
         grad_out_buf = _local_scatter(grad_out.contiguous(), pos_g)
         grad_in_buf = fmoe_native.smart_sch_backward(
                 grad_out_buf,
                 local_expert_count, global_expert_count,
                 stored_models,
-                pos_s.shape[0], fwd_batch_size,
-                world_size, _expert_backward)
+                pos_s.shape[0], fwd_batch_size, ctx.expert_size,
+                world_size, _expert_backward,
+                stash_fn, pop_fn, collect_fn, set_grad_fn)
         grad_in = _local_gather(grad_in_buf, pos_s, inp_batch_size)
 
-        return (None, grad_in, None, None, None, None, None, None, None, None)
+        return (None, None, grad_in, None, None, None, None, None, None, None, None)
 
 
-def _fmoe_general_global_forward(inp, gate, expert_fn, n_expert, world_size):
+def _fmoe_general_global_forward(inp, gate, expert_fn, n_expert, world_size, experts=None):
     # TODO: Using multiple tensors as input is to be supported.
     assert(isinstance(inp, torch.Tensor))
     # TODO: Support many experts on each process
@@ -98,7 +120,7 @@ def _fmoe_general_global_forward(inp, gate, expert_fn, n_expert, world_size):
         topk = gate.shape[1]
     out_batch_size = inp.shape[0] * topk
 
-    return MoEForward.apply(expert_fn, inp,
+    return MoEForward.apply(expert_fn, experts, inp,
             torch.div(pos, topk, rounding_mode='floor'), pos,
             local_expert_count, global_expert_count, stored_models,
             fwd_batch_size, out_batch_size, world_size)

--- a/fmoe/fastermoe/shadow_policy.py
+++ b/fmoe/fastermoe/shadow_policy.py
@@ -1,0 +1,73 @@
+import os
+import torch
+import torch.distributed as dist
+
+
+from .config import float_from_env, switch_from_env
+from fmoe.functions import get_moe_group
+
+
+def global_policy(local_expert_count, _gec, num_expert, world_size):
+    r"""
+    This is the policy for two-layer MLPs, using the formula in the PPoPP paper.
+    A few parameters are used in this policy.
+    * `d_model`: feature length of the MLP input and output.
+    * `alpha`: the ratio of the MLP's hidden size to `d_model`.
+    * `bw_net`: bandwidth of the network (GBps)
+    * `bw_mm`: computation throughput of performing GeMM (FLOPs)
+    """
+    bw_net = float_from_env('FMOE_FASTER_GLBPLC_NETBW', 50 * 1e9 / 8)
+    bw_mm = float_from_env('FMOE_FASTER_GLBPLC_GPUTP', 11.5e12)
+    alpha = float_from_env('FMOE_FASTER_GLBPLC_ALPHA', 2)
+    d_model = float_from_env('FMOE_FASTER_GLBPLC_DMODEL', 2048)
+
+    moe_group = get_moe_group()
+    local_expert_count = local_expert_count.cuda()
+    agecs = [torch.empty_like(local_expert_count) for _ in range(world_size)]
+    dist.all_gather(agecs, local_expert_count, group=moe_group)
+    all_global_expert_count = torch.stack(agecs)
+
+    # TODO: data type other than float
+    data_size = 4 
+
+    fwd_expert_counts = all_global_expert_count.sum(1).cpu()
+    B_ws, indices = fwd_expert_counts.flatten().sort(0, descending=True)
+
+    alphaH2 = alpha * (d_model ** 2)
+    B_w = B_ws[0]
+
+    comm = float('+inf')
+    send_feature_time = d_model * data_size / bw_net
+    send_model_time = 2 * alphaH2 * data_size / bw_net
+    comp_time = 4 * alphaH2 / bw_mm
+    lat_base = 3 * comp_time * B_w + 4 * send_feature_time * B_w
+
+    res = torch.zeros(world_size * num_expert, dtype=torch.bool)
+    shadow_time = 0
+
+    for i, index in enumerate(indices):
+        if i + 1 == indices.numel():
+            break
+        B_k = B_ws[i + 1]
+        shadow_time += send_model_time
+        lat_new = 3 * comp_time * B_k + 4 * send_feature_time * B_k + shadow_time
+
+        if lat_new < lat_base:
+            lat_base = lat_new
+            res[index] = True
+        else:
+            break
+    return res
+
+
+def no_shadow_policy(_lec, _gec, num_expert, world_size):
+    res = torch.zeros(world_size * num_expert, dtype=bool)
+    return res
+
+
+def get_shadow_policy(d_model=None):
+    if d_model is not None and 'FMOE_FASTER_GLBPLC_DMODEL' not in os.environ:
+        os.environ['FMOE_FASTER_GLBPLC_DMODEL'] = str(d_model)
+    if not switch_from_env('FMOE_FASTER_SHADOW_ENABLE'):
+        return no_policy
+    return global_policy

--- a/fmoe/functions.py
+++ b/fmoe/functions.py
@@ -10,10 +10,19 @@ import fmoe_cuda
 from .utils import get_torch_default_comm
 
 
+_moe_group = None
+
+
 def ensure_comm(t, comm):
     if comm is None:
         comm = get_torch_default_comm()
+    global _moe_group
+    _moe_group = comm
     fmoe_cuda.ensure_nccl(comm, t)
+
+
+def get_moe_group():
+    return _moe_group
 
 
 def count_by_gate(gate, num_expert, world_size, require_pos=True):

--- a/fmoe/layers.py
+++ b/fmoe/layers.py
@@ -21,7 +21,7 @@ def mark_module_parallel_comm(module, comm):
         setattr(p, "dp_comm", comm)
 
 
-def _fmoe_general_global_forward(inp, gate, expert_fn, num_expert, world_size):
+def _fmoe_general_global_forward(inp, gate, expert_fn, num_expert, world_size, **kwargs):
     r"""
     A private function that performs the following steps to complete the MoE
     computation.
@@ -227,7 +227,9 @@ class FMoE(nn.Module):
             gate_top_k_idx = gate_top_k_idx[mask == 0, :]
 
         fwd = _fmoe_general_global_forward(
-            moe_inp, gate_top_k_idx, self.expert_fn, self.num_expert, self.world_size
+            moe_inp, gate_top_k_idx, self.expert_fn,
+            self.num_expert, self.world_size,
+            experts=self.experts
         )
 
         # recover deleted tensors

--- a/fmoe/layers.py
+++ b/fmoe/layers.py
@@ -11,6 +11,8 @@ from .functions import MOEScatter, MOEGather
 from .functions import AllGather, Slice
 from .gates import NaiveGate
 
+from .fastermoe.config import switch_from_env
+
 
 def mark_module_parallel_comm(module, comm):
     r"""
@@ -76,7 +78,9 @@ def _fmoe_general_global_forward(inp, gate, expert_fn, num_expert, world_size, *
     return outp
 
 
-if os.environ.get('FMOE_FASTER_SCHEDULE_ENABLE', '0') in ['1', 'ON']:
+fmoe_faster_schedule = False
+if switch_from_env('FMOE_FASTER_SCHEDULE_ENABLE', False):
+    fmoe_faster_schedule = True
     from .fastermoe.schedule import _fmoe_general_global_forward
 
 

--- a/tests/test_ddp.py
+++ b/tests/test_ddp.py
@@ -3,6 +3,7 @@ import random
 import os
 import sys
 from typing import Dict
+import random
 
 import pytest
 import torch
@@ -19,7 +20,6 @@ def _ensure_initialized():
         os.environ["WORLD_SIZE"] = os.environ.get("OMPI_COMM_WORLD_SIZE", "1")
         os.environ["CUDA_VISIBLE_DEVICES"] = os.environ["RANK"]
         os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", "localhost")
-        os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "12211")
     if not dist.is_initialized():
         dist.init_process_group(backend="nccl")
 

--- a/tests/test_faster_shadow.py
+++ b/tests/test_faster_shadow.py
@@ -62,16 +62,18 @@ def _test_faster_shadow(d_model, batch_size, n_expert):
     dist.broadcast(stored_models, 0)
     stored_models = stored_models.cpu()
 
+    # if rank == 0:
+         # print('stored models {}'.format(stored_models))
+
     ensure_comm(x1, None)
     y1 = smart_fwd(x1, topk_idx, ef1, n_expert, world_size, experts=m1, stored_models=stored_models)
-    # y1.sum().backward()
+    y1.sum().backward()
 
     y2 = naive_fwd(x2, topk_idx, ef2, n_expert, world_size, experts=m2)
-    # y2.sum().backward()
-    _assert_numerical(['out'], [y1], [y2], rank)
-    # _assert_numerical(['out', 'grad_in', 'grad_bias', 'grad_weight'],
-    #         [y1, x1.grad, m1.bias.grad, m1.weight.grad],
-    #         [y2, x2.grad, m2.bias.grad, m2.weight.grad], rank)
+    y2.sum().backward()
+    _assert_numerical(['out', 'grad_in', 'grad_bias', 'grad_weight'],
+            [y1, x1.grad, m1.bias.grad, m1.weight.grad],
+            [y2, x2.grad, m2.bias.grad, m2.weight.grad], rank)
 
 
 if __name__ == '__main__':

--- a/tests/test_faster_shadow.py
+++ b/tests/test_faster_shadow.py
@@ -1,0 +1,83 @@
+import pytest
+
+import os
+import sys
+import json
+import math
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from fmoe.functions import ensure_comm
+from test_ddp import _ensure_initialized, _run_distributed
+from test_numerical import _assert_numerical
+from fmoe.fastermoe.schedule import _fmoe_general_global_forward as smart_fwd
+from fmoe.layers import _fmoe_general_global_forward as naive_fwd
+
+
+@pytest.mark.parametrize("n_process", [8])
+@pytest.mark.parametrize("d_model", [1024])
+@pytest.mark.parametrize("batch_size", [16])
+@pytest.mark.parametrize("n_expert", [1])
+@pytest.mark.parametrize("group_sz", [1, 2, 4])
+def test_faster_shadow(n_process, d_model, batch_size, n_expert, group_sz):
+    _run_distributed('_test_faster_shadow',
+            n_process,
+            {
+                'd_model': d_model,
+                'batch_size': batch_size,
+                'n_expert': n_expert
+            },
+            script=__file__,
+            env=dict(
+                FMOE_FASTER_GROUP_SIZE=str(group_sz)
+            )
+    )
+
+
+def _test_faster_shadow(d_model, batch_size, n_expert):
+    _ensure_initialized()
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    x1 = torch.rand(batch_size, d_model).cuda()
+    x1.requires_grad = True
+    x2 = x1.data.clone()
+    x2.requires_grad = True
+    topk_idx = torch.randint(0, world_size * n_expert, (batch_size, 2)).cuda()
+    m1 = torch.nn.Linear(d_model, d_model).cuda()
+    m2 = torch.nn.Linear(d_model, d_model).cuda()
+    with torch.no_grad():
+        m2.weight.copy_(m1.weight)
+        m2.bias.copy_(m1.bias)
+
+    def ef1(x, fec):
+        y = m1(x)
+        return y
+    def ef2(x, fec):
+        y = m2(x)
+        return y
+
+    stored_models = torch.randint(0, 2, (world_size,)).bool().cuda()
+    dist.broadcast(stored_models, 0)
+    stored_models = stored_models.cpu()
+
+    ensure_comm(x1, None)
+    y1 = smart_fwd(x1, topk_idx, ef1, n_expert, world_size, experts=m1, stored_models=stored_models)
+    # y1.sum().backward()
+
+    y2 = naive_fwd(x2, topk_idx, ef2, n_expert, world_size, experts=m2)
+    # y2.sum().backward()
+    _assert_numerical(['out'], [y1], [y2], rank)
+    # _assert_numerical(['out', 'grad_in', 'grad_bias', 'grad_weight'],
+    #         [y1, x1.grad, m1.bias.grad, m1.weight.grad],
+    #         [y2, x2.grad, m2.bias.grad, m2.weight.grad], rank)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) >= 3:
+        args = json.loads(sys.argv[2])
+        locals()[sys.argv[1]](**args)
+    else:
+        # test_faster_shadow(8, 16, 16, 1, 2)
+        _test_faster_shadow(4, 2, 1)


### PR DESCRIPTION
Add the expert shadowing techinque in PPoPP'22 paper _FasterMoE: Modeling and Optimizing Training of Large-Scale Dynamic Pre-Trained Models_.

The code is rewritten, as FasterMoE's open source version is toooo dirty. Documents will be added later when the whole project is integrated into FastMoE.

A few bugs of smart scheduling are found and fixed in this PR. 

For simplicity, this feature can only enabled when smart scheduling is enabled.

To support arbitrary expert module, several hacks of the workers' expert module are used to load different parameters of different experts. Therefore, the expert module has to be totally of the same structure.