### PR TITLE
fix bug: skip computeFn when batch is empty

### DIFF
--- a/cuda/fastermoe/smart_schedule.h
+++ b/cuda/fastermoe/smart_schedule.h
@@ -80,6 +80,9 @@ void computeFn(py::function fn, c10::Device device,
         scalar_t* inp_buf, scalar_t* out_buf,
         long idx, long offset, long micro_batch_size, long d_model,
         CudaStreamManager* smgr) {
+    if(micro_batch_size == 0) {
+        return;
+    }
     auto options = torch::TensorOptions()
         .dtype(c10::CppTypeToScalarType<scalar_t>::value)
         .device(device)

--- a/fmoe/fastermoe/shadow_policy.py
+++ b/fmoe/fastermoe/shadow_policy.py
@@ -69,5 +69,5 @@ def get_shadow_policy(d_model=None):
     if d_model is not None and 'FMOE_FASTER_GLBPLC_DMODEL' not in os.environ:
         os.environ['FMOE_FASTER_GLBPLC_DMODEL'] = str(d_model)
     if not switch_from_env('FMOE_FASTER_SHADOW_ENABLE'):
-        return no_policy
+        return no_shadow_policy
     return global_policy


### PR DESCRIPTION
torch::from_blob will meet error when micro_batch_size = 0