### PR TITLE
smart_schedule.h bug fixed

### DIFF
--- a/cuda/fastermoe/smart_schedule.h
+++ b/cuda/fastermoe/smart_schedule.h
@@ -169,7 +169,8 @@ void fmoe_cuda_fused_forward_impl(
             if (i / num_expert == rank) {
                 cudaEventCreate(&evt_get);
                 cudaEventRecord(evt_get, torch_stream);
-                cudaStreamWaitEvent(smgr->stream(1), evt_get);
+                cudaStreamWaitEvent(smgr->stream(1), evt_get, 0);
+//                cudaStreamWaitEvent(smgr->stream(1), evt_get);
                 cudaEventDestroy(evt_get);
             }
             NCCL_SAFE_CALL(ncclBcast((void*)params[si].data_ptr<scalar_t>(),


### PR DESCRIPTION
smart_schedule.h bug fixed for cuda10.2, montioned in [https://github.com/laekov/fastmoe/issues/111](url)
(cherry picked from commit 8c7cf19860889762602bbb13ff41b21c959b0064)
