### PR TITLE
convert input to same type as weight for mixed precision training

### DIFF
--- a/fmoe/linear.py
+++ b/fmoe/linear.py
@@ -63,14 +63,14 @@ class FMoELinear(nn.Module):
             self.bias = nn.Parameter(torch.zeros(num_expert, out_feat))
         else:
             self.register_parameter("bias", None)
-
+          
         self.reset_parameters()
 
     def forward(self, inp, fwd_expert_count):
         r"""
         Call MOE function
         """
-        x = MOELinear.apply(inp, fwd_expert_count, self.weight, self.bias)
+        x = MOELinear.apply(inp.float(), fwd_expert_count, self.weight, self.bias)
         return x
 
     def extra_repr(self) -> str:

--- a/fmoe/linear.py
+++ b/fmoe/linear.py
@@ -70,7 +70,7 @@ class FMoELinear(nn.Module):
         r"""
         Call MOE function
         """
-        x = MOELinear.apply(inp.float(), fwd_expert_count, self.weight, self.bias)
+        x = MOELinear.apply(inp.type_as(self.weight), fwd_expert_count, self.weight, self.bias)
         return x
 
     def extra_repr(self) -> str:


### PR DESCRIPTION
When using CUDA Automatic Mixed Precision FMoELinear forward function throws type error as input is half() and weights are float().

Not sure if it works also using `inp.type_as(self.weight)` as it is an in-place operation that can cause troubles when backpropagating (I've tried to cast the weights with it and it threw an error).

This is the only solution that worked for me and I think it may help to support AMP especially when training with limited resources and transformers.