### PR TITLE
[Feature] Make bias of gate optional for naive_gate and its subclasses.

### DIFF
--- a/fmoe/gates/dc_gate.py
+++ b/fmoe/gates/dc_gate.py
@@ -13,9 +13,9 @@ from .utils import limit_by_capacity
 
 class DCGate(NaiveGate):
     def __init__(self, d_model, num_expert, world_size,
-            topk=2, capacity=(1.2, 2.4), random_routing=True):
+            topk=2, capacity=(1.2, 2.4), random_routing=True, gate_bias=True):
         assert topk == 2, 'topk should be 2 in gshard'
-        super().__init__(d_model, num_expert, world_size, top_k=2)
+        super().__init__(d_model, num_expert, world_size, top_k=2, gate_bias=gate_bias)
         self.capacity = capacity
         self.random_routing = random_routing
 

--- a/fmoe/gates/faster_gate.py
+++ b/fmoe/gates/faster_gate.py
@@ -31,8 +31,8 @@ except Exception:
 
 
 class FasterGate(NaiveGate):
-    def __init__(self, d_model, n_expert, world_size, node_rank):
-        super().__init__(d_model, n_expert, world_size, top_k=2)
+    def __init__(self, d_model, n_expert, world_size, node_rank, gate_bias=True):
+        super().__init__(d_model, n_expert, world_size, top_k=2, gate_bias=gate_bias)
         self.ne_per_node = nw_per_node * n_expert
         self.ogn_ratio = .14
         try:

--- a/fmoe/gates/gshard_gate.py
+++ b/fmoe/gates/gshard_gate.py
@@ -11,9 +11,9 @@ import fmoe_cuda as fmoe_native
 
 class GShardGate(NaiveGate):
     def __init__(self, d_model, num_expert, world_size,
-            topk=2, capacity=(1.2, 2.4), random_routing=True):
+            topk=2, capacity=(1.2, 2.4), random_routing=True, gate_bias=True):
         assert topk == 2, 'topk should be 2 in gshard'
-        super().__init__(d_model, num_expert, world_size, top_k=2)
+        super().__init__(d_model, num_expert, world_size, top_k=2, gate_bias=gate_bias)
         self.capacity = capacity
         self.random_routing = random_routing
 

--- a/fmoe/gates/naive_gate.py
+++ b/fmoe/gates/naive_gate.py
@@ -18,9 +18,9 @@ class NaiveGate(BaseGate):
     `Gate` module.
     """
 
-    def __init__(self, d_model, num_expert, world_size, top_k=2):
+    def __init__(self, d_model, num_expert, world_size, top_k=2, gate_bias=True):
         super().__init__(num_expert, world_size)
-        self.gate = nn.Linear(d_model, self.tot_expert)
+        self.gate = nn.Linear(d_model, self.tot_expert, bias = gate_bias)
         self.top_k = top_k
 
     def forward(self, inp, return_all_scores=False):

--- a/fmoe/gates/swipe_gate.py
+++ b/fmoe/gates/swipe_gate.py
@@ -13,8 +13,8 @@ import fmoe_cuda as fmoe_native
 
 
 class SwipeGate(NaiveGate):
-    def __init__(self, d_model, num_expert, world_size, top_k=2):
-        super().__init__(d_model, num_expert, world_size, top_k)
+    def __init__(self, d_model, num_expert, world_size, top_k=2, gate_bias=True):
+        super().__init__(d_model, num_expert, world_size, top_k, gate_bias)
 
     def swipe_once(self, idx, capacity, bias):
         with torch.no_grad():

--- a/fmoe/gates/switch_gate.py
+++ b/fmoe/gates/switch_gate.py
@@ -15,9 +15,9 @@ class SwitchGate(NaiveGate):
     """
 
     def __init__(self, d_model, num_expert, world_size, topk=1,
-            switch_eps=.1, capacity=(1.2, 2.4)):
+            switch_eps=.1, capacity=(1.2, 2.4), gate_bias=True):
         assert topk == 1, 'topk should be 1 in switch'
-        super().__init__(d_model, num_expert, world_size, top_k=1)
+        super().__init__(d_model, num_expert, world_size, top_k=1, gate_bias=gate_bias)
         self.switch_eps = switch_eps
         self.capacity = capacity
 

--- a/fmoe/layers.py
+++ b/fmoe/layers.py
@@ -121,6 +121,7 @@ class FMoE(nn.Module):
         gate_hook=None,
         mask=None,
         mask_dict=None,
+        gate_bias=True,
     ):
         super().__init__()
         self.num_expert = num_expert
@@ -149,7 +150,10 @@ class FMoE(nn.Module):
         else:
             self.experts_fused = True
 
-        self.gate = gate(d_model, num_expert, world_size, top_k)
+        if issubclass(gate, NaiveGate):
+            self.gate = gate(d_model, num_expert, world_size, top_k, gate_bias=gate_bias)
+        else:
+            self.gate = gate(d_model, num_expert, world_size, top_k)
         self.gate_hook = gate_hook
         self.mask = mask
         self.mask_dict = mask_dict

--- a/fmoe/layers.py
+++ b/fmoe/layers.py
@@ -105,6 +105,8 @@ class FMoE(nn.Module):
     * `gate` is a gate class which can found in `fmoe.gates`.
     * `expert` can be specified as a module class, it is used to generate
     `num_expert` expert modules.
+    * `gate_bias` is only valid for naive_gate and its subclasses, it means
+    whether to add bias to the gate module.
     """
 
     def __init__(

--- a/tests/test_mimo.py
+++ b/tests/test_mimo.py
@@ -65,8 +65,8 @@ class MyExpert(nn.Module):
 
 
 class MyGate(NaiveGate):
-    def __init__(self, d_model, num_expert, world_size, top_k=2):
-        super().__init__(d_model, num_expert, world_size, top_k)
+    def __init__(self, d_model, num_expert, world_size, top_k=2, gate_bias=True):
+        super().__init__(d_model, num_expert, world_size, top_k, gate_bias=gate_bias)
 
     def forward(self, inp, return_all_scores=False):
         if type(inp) == dict:


### PR DESCRIPTION
Some of public MoE weights don't need bias of gates. Make bias of gate optional can impove compatibility of newly public MoE weights. 