### PR TITLE
No hiding output when using `pytest -s`

### DIFF
--- a/tests/test_ddp.py
+++ b/tests/test_ddp.py
@@ -46,7 +46,6 @@ def _run_distributed(func, world_size, args: Dict, script=__file__, env=dict()):
         env["OMPI_COMM_WORLD_RANK"] = str(i)
         p = subprocess.Popen(
             [sys.executable, script, func, json.dumps(args)],
-            stdout=subprocess.PIPE,
             env=env
         )
         ps.append(p)


### PR DESCRIPTION
Now output from each process goes onto the screen with its rank as a prefix if you run with `pytest -s`. `pytest` without `-s` is still clean.